### PR TITLE
Baryon agents 서비스 카드 추가

### DIFF
--- a/languages.js
+++ b/languages.js
@@ -102,6 +102,13 @@ const translations = {
                 feature2: 'Data Sync',
                 feature3: 'Backend'
             },
+            baryonWorkspace: {
+                title: 'Baryon Agents Parallel Workspace',
+                description: 'Integrated environment for agents parallel programming with Git worktree isolation and spec-driven workflows',
+                feature1: 'Parallel Agents',
+                feature2: 'Git Worktree Isolation',
+                feature3: 'Spec-driven Workflow'
+            },
             comingSoon: {
                 title: 'New Service Coming Soon',
                 description: 'We are developing an innovative AI solution with our new team member. Stay tuned for an amazing service that will be unveiled soon.',
@@ -243,6 +250,13 @@ const translations = {
                 feature1: 'API 게이트웨이',
                 feature2: '데이터 동기화',
                 feature3: '백엔드'
+            },
+            baryonWorkspace: {
+                title: 'Baryon Agents Parallel Workspace',
+                description: 'Git 워크트리 분리와 스펙 기반 워크플로우를 갖춘 에이전트 병렬 프로그래밍 통합 환경',
+                feature1: '에이전트 병렬',
+                feature2: 'Git 워크트리 분리',
+                feature3: '스펙 기반 워크플로우'
             },
             comingSoon: {
                 title: '새로운 서비스 준비중',

--- a/sections/services.html
+++ b/sections/services.html
@@ -7,6 +7,32 @@
         </div>
         
         <div class="services-grid">
+            <!-- Service 0: Baryon Agents Parallel Workspace -->
+            <div class="service-card" data-service="baryonWorkspace">
+                <div class="service-image">
+                    <div class="service-image-placeholder">
+                        <!-- 이미지가 들어갈 공간 -->
+                    </div>
+                </div>
+                <div class="service-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                        <rect x="2" y="2" width="20" height="20" rx="2" ry="2"/>
+                        <path d="M7 7h10v10H7z"/>
+                    </svg>
+                </div>
+                <div class="service-content">
+                    <h3 data-i18n="services.baryonWorkspace.title">Baryon Agents Parallel Workspace</h3>
+                    <p data-i18n="services.baryonWorkspace.description">Integrated environment for agents parallel programming with Git worktree isolation and spec-driven workflows</p>
+                    <div class="service-features">
+                        <span class="feature-tag" data-i18n="services.baryonWorkspace.feature1">Parallel Agents</span>
+                        <span class="feature-tag" data-i18n="services.baryonWorkspace.feature2">Git Worktree Isolation</span>
+                        <span class="feature-tag" data-i18n="services.baryonWorkspace.feature3">Spec-driven Workflow</span>
+                    </div>
+                    <a href="https://marketplace.visualstudio.com/items?itemName=a3agent-spec-baryonai.a3agent-spec-baryonai" target="_blank" rel="noopener noreferrer" class="service-link" data-i18n="services.visitSite">
+                        Visit Site <span class="arrow">→</span>
+                    </a>
+                </div>
+            </div>
             <!-- Service 1: miri.dev -->
             <div class="service-card" data-service="miri">
                 <div class="service-image">


### PR DESCRIPTION
Add 'Baryon Agents Parallel Workspace' service card to the homepage with i18n support, prioritizing its display and including an image placeholder.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents%3Fid=bc-22a6f483-719b-4e2f-9dc4-50d91b1c2829) · [Cursor](https://cursor.com/background-agent%3FbcId=bc-22a6f483-719b-4e2f-9dc4-50d91b1c2829)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)

[Slack Thread](https://baryonai.slack.com/archives/C095BLTKL4D/p1753059328745879%3Fthread_ts=1753059328.745879